### PR TITLE
Export response types

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="node" />
-import { ClassificationResult, ExtractionResult, Webhook } from "./types";
+import type { ClassificationResult, ExtractionResult, Webhook } from "./types";
 export declare class SensibleSDK {
     apiKey: string;
     constructor(apiKey: string);
@@ -39,4 +39,4 @@ type ClassificationRequest = {
     id: string;
     downloadLink: string;
 };
-export {};
+export type { ClassificationResult, ExtractionResult, Webhook };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
-  "name": "sensible-sdk",
+  "name": "sensible-api",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "sensible-sdk",
+      "name": "sensible-api",
       "version": "0.0.1",
+      "license": "MIT",
       "dependencies": {
         "got": "^11.8.5"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sensible-api",
-  "version": "0.0.1",
+  "version": "0.0.3",
   "description": "Javascript SDK for Sensible, the developer-first platform for extracting structured data from documents so that you can build document-automation features into your SaaS products",
   "keywords": ["IDP","parsing","conversion","openai","processing","csv","excel","convert","json","LLMs","pdf","png","tiff","jpeg","doc","docx","document","text","data","extraction","extract","classification","classify","sensible","openapi","gpt-3","gpt-4","senseml","automation","sdk","query","document-processing"," intelligent-document-processing"," pdf-conversion"," pdf-extraction"," document-extraction"," pdf-crawler","pdf-parser","pdf-extract","pdf-to-data","document-data-extraction","document-automation"],
   "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import got, { HTTPError } from "got";
 import * as querystring from "node:querystring";
 import { promisify } from "util";
-import { ClassificationResult, ExtractionResult, Webhook } from "./types";
+import type { ClassificationResult, ExtractionResult, Webhook } from "./types";
 
 const baseUrl = "https://api.sensible.so/v0";
 
@@ -300,3 +300,5 @@ function isClassificationResponse(
     typeof response.download_link === "string"
   );
 }
+
+export type { ClassificationResult, ExtractionResult, Webhook };


### PR DESCRIPTION
Turns out we weren't exporting the response types properly to be able to access them externally. Also bumped the version number, but I'm not sure what your process is for publishing. So that might not be needed.